### PR TITLE
Feed gaslit response to simulator

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,10 +8,12 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-honcho = Honcho(api_key="test", environment="local")
+honcho = Honcho(environment="local")
 app = honcho.apps.get_or_create("NYTW Yousim Demo")
 user = honcho.apps.users.get_or_create(app_id=app.id, name="test_user")
-session = honcho.apps.users.sessions.create(app_id=app.id, user_id=user.id, location_id="cli")
+session = honcho.apps.users.sessions.create(
+    app_id=app.id, user_id=user.id, location_id="cli"
+)
 
 gaslit_claude = GaslitClaude(name="", insights=[], history=[])
 simulator = Simulator(history=[])
@@ -20,20 +22,28 @@ simulator = Simulator(history=[])
 async def chat():
     name = input("Enter a name: ")
     if name == "exit":
-        honcho.apps.users.sessions.delete(app_id=app.id, session_id=session.id, user_id=user.id)
+        honcho.apps.users.sessions.delete(
+            app_id=app.id, session_id=session.id, user_id=user.id
+        )
         sys.exit()
+    count = 0
     while True:
-        history_iter = honcho.apps.users.sessions.messages.list(app_id=app.id, session_id=session.id, user_id=user.id)
+        history_iter = honcho.apps.users.sessions.messages.list(
+            app_id=app.id, session_id=session.id, user_id=user.id
+        )
+        gaslit_claude.history = []
+        simulator.history = []
         for message in history_iter:
             if message.is_user:
-                gaslit_claude.history += [{'role': 'user', 'content': message.content}]
-                simulator.history += [{'role': 'assistant', 'content': message.content}]
+                gaslit_claude.history += [{"role": "user", "content": message.content}]
+                simulator.history += [{"role": "assistant", "content": message.content}]
             else:
-                gaslit_claude.history += [{'role': 'assistant', 'content': message.content}]
-                simulator.history += [{'role': 'user', 'content': message.content}]
+                gaslit_claude.history += [
+                    {"role": "assistant", "content": message.content}
+                ]
+                simulator.history += [{"role": "user", "content": message.content}]
 
         gaslit_claude.name = name
-        # simulator.name = name
         gaslit_response = ""
         response = gaslit_claude.stream_async()
         print("\033[94mGASLIT CLAUDE:\033[0m")
@@ -44,6 +54,10 @@ async def chat():
 
         sleep(0.5)
 
+        # If you feed the input on the first output it will cause Claude to refuse to
+        # play
+        if count != 0:
+            simulator.history += [{"role": "user", "content": gaslit_response}]
         simulator_response = ""
         response = simulator.stream_async()
         print("\033[93mSIMULATOR:\033[0m")
@@ -52,20 +66,32 @@ async def chat():
             simulator_response += chunk.content
         print("\n")
 
+        # if not len(simulator_response) > 0:
+        #     print("\033[45mINVALID OUTPUT\033[0m")
+        #     pprint(simulator.dump(), indent=4)
+        #     print("\n")
+
         if not simulator_response.strip():
             simulator_response = "simulator@anthropic:~/$"
 
-
         honcho.apps.users.sessions.messages.create(
-            session_id=session.id, app_id=app.id, user_id=user.id, content=gaslit_response, is_user=False
+            session_id=session.id,
+            app_id=app.id,
+            user_id=user.id,
+            content=gaslit_response,
+            is_user=False,
         )
 
         honcho.apps.users.sessions.messages.create(
-            session_id=session.id, app_id=app.id, user_id=user.id, content=simulator_response, is_user=True
+            session_id=session.id,
+            app_id=app.id,
+            user_id=user.id,
+            content=simulator_response,
+            is_user=True,
         )
 
+        count += 1
 
 
 if __name__ == "__main__":
     asyncio.run(chat())
-


### PR DESCRIPTION
Found a few things

- The history was never cleared between conversations turns so it just kept exponentionally appending to the history list
- The `gaslit_response` was never being fed into the `simulator` meaning that the latest message for the `simulator` was an assistant message

According to the [Claude API](https://docs.anthropic.com/en/api/messages)

> Each input message must be an object with a role and content. You can specify a single user-role message, or you can include multiple user and assistant messages. The first message must always use the user role.

> If the final message uses the assistant role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.

So because we had the model output things like "awaiting response" or a shell prompt like `simulator@anthropic:~/$ ` this would look like a valid end point for the model and it would not generate any additional tokens. 

What I did was clear the history on each loop and then feed the `gaslit_response` to the `simulator`. The one thing to note is that on the first conversation turn I don't feed it to the simulator. I found that if I did the simulator would always respond saying it is an AI assistant and cannot run those commands. Letting it generate once made it output the initial ASCII art and whatnot which prevented it from complaining later. 

A bit of a Jank setup and I'm sure there's some initial prompting that would help the simulator not do that such as adding an additional user and assistant message at the beginning of the simulator. Although this makes it not output all that crazy stuff at the beginning which is fun

Some other things I tried

- expliclity calling the prompt in the `Simulator` class a System message. This prevented claude from complaining but less wacky results. Those results are in the `explicit-system` branch


